### PR TITLE
chore: upgrade ws to ^8.21.0 for security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@evpower/ocpp-ts",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@evpower/ocpp-ts",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
         "status-code-enum": "^1.0.0",
         "uuid": "^8.3.2",
-        "ws": "^8.18.3"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/glob": "^9.0.0",
@@ -10722,9 +10722,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evpower/ocpp-ts",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "OCPP 1.6: Open Charge Point Protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -30,7 +30,7 @@
     "ajv": "^6.12.6",
     "status-code-enum": "^1.0.0",
     "uuid": "^8.3.2",
-    "ws": "^8.18.3"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/glob": "^9.0.0",


### PR DESCRIPTION
Bumps ws from ^8.18.3 (resolved 8.20.0) to ^8.21.0 to clear:
- GHSA-58qx-3vcg-4xpx (uninitialized memory disclosure, fixed 8.20.1)
- GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS, fixed 8.21.0)

Raises the range floor since 8.20.0 still satisfied ^8.18.3. Bumps package version to 0.4.6 for republish so downstream consumers can pick up the patched ws. Build and full jest suite (incl. WebSocket + ServerPing) pass.